### PR TITLE
Fix typo in fluid bind group parameter name

### DIFF
--- a/src/euler_fluid/fluid_bind_group.rs
+++ b/src/euler_fluid/fluid_bind_group.rs
@@ -765,7 +765,7 @@ pub(super) fn prepare_fluid_bind_groups(
 
 pub(super) fn prepare_fluid_bind_group_for_resources(
     mut commands: Commands,
-    pilelines: Res<FluidPipelines>,
+    pipelines: Res<FluidPipelines>,
     obstacles: Res<SolidObstaclesBuffer>,
     render_device: Res<RenderDevice>,
     gpu_images: Res<RenderAssets<GpuImage>>,
@@ -775,7 +775,7 @@ pub(super) fn prepare_fluid_bind_group_for_resources(
     let mut param = (gpu_images, fallback_image, buffers);
     let obstacles_bind_group = obstacles
         .as_bind_group(
-            &pilelines.obstacles_bind_group_layout,
+            &pipelines.obstacles_bind_group_layout,
             &render_device,
             &mut param,
         )


### PR DESCRIPTION
## Summary
- rename the `prepare_fluid_bind_group_for_resources` parameter from `pilelines` to `pipelines`
- update internal references to use the corrected name

## Testing
- `cargo build` *(fails: missing system dependency `wayland-client` required by `wayland-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_68fca9e02388832f8c6d86cc9ef6ad71