### PR TITLE
fix: shader loading on webgpu.

### DIFF
--- a/src/euler_fluid/fluid_to_solid.rs
+++ b/src/euler_fluid/fluid_to_solid.rs
@@ -47,11 +47,11 @@ pub(crate) struct SampleForcesResource {
 
 #[derive(Component, Clone, ExtractComponent, AsBindGroup)]
 pub(crate) struct AccumulateForcesResource {
-    #[storage(0, visibility(compute), read_only)]
+    #[storage(0, visibility(compute))]
     pub bins_force_x: Handle<ShaderStorageBuffer>,
-    #[storage(1, visibility(compute), read_only)]
+    #[storage(1, visibility(compute))]
     pub bins_force_y: Handle<ShaderStorageBuffer>,
-    #[storage(2, visibility(compute), read_only)]
+    #[storage(2, visibility(compute))]
     pub bins_torque: Handle<ShaderStorageBuffer>,
     #[storage(3, visibility(compute))]
     pub forces: Handle<ShaderStorageBuffer>,

--- a/src/euler_fluid/shaders/fluid_to_solid/accumulate_forces.wgsl
+++ b/src/euler_fluid/shaders/fluid_to_solid/accumulate_forces.wgsl
@@ -7,9 +7,10 @@ struct Force {
     torque: f32,
 }
 
-@group(0) @binding(0) var<storage, read> bins_force_x: array<atomic<i32>>;
-@group(0) @binding(1) var<storage, read> bins_force_y: array<atomic<i32>>;
-@group(0) @binding(2) var<storage, read> bins_torque: array<atomic<i32>>;
+// Note: atomic requires read_write storage buffer.
+@group(0) @binding(0) var<storage, read_write> bins_force_x: array<atomic<i32>>;
+@group(0) @binding(1) var<storage, read_write> bins_force_y: array<atomic<i32>>;
+@group(0) @binding(2) var<storage, read_write> bins_torque: array<atomic<i32>>;
 @group(0) @binding(3) var<storage, read_write> forces: array<Force>;
 
 @compute @workgroup_size(1, 1, 1)


### PR DESCRIPTION
On WebGPU, read_write access is required for atomic variables